### PR TITLE
Add support for no-important

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ npm install --save-dev jest-aphrodite-react
 At the top of your test file:
 
 ```javascript
-import { serializer } from 'jest-aphrodite-react';
+import { aphroditeSerializer } from 'jest-aphrodite-react'; // or jest-aphrodite-react/no-important
 
-expect.addSnapshotSerializer(serializer);
+expect.addSnapshotSerializer(aphroditeSerializer);
 ```
 
 Or in your Jest serializer config:
 
 ```javascript
 {
-  snapshotSerializers: ['jest-aphrodite-react'];
+  snapshotSerializers: ['jest-aphrodite-react']; // or jest-aphrodite-react/no-important
 }
 ```
 

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -1,7 +1,11 @@
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const { StyleSheetTestUtils } = require('aphrodite');
+const {
+  StyleSheetTestUtils: StyleSheetTestUtilsNoImportant,
+} = require('aphrodite/no-important');
 
 StyleSheetTestUtils.suppressStyleInjection();
+StyleSheetTestUtilsNoImportant.suppressStyleInjection();
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/no-important.d.ts
+++ b/no-important.d.ts
@@ -1,0 +1,1 @@
+export * from './typings/no-important';

--- a/no-important.js
+++ b/no-important.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/no-important.js');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepublish": "npm run build",
     "test": "jest -c jest.config.json"
   },
-  "files": ["lib", "typings"],
+  "files": ["lib", "typings", "no-important.js", "no-important.d.ts"],
   "repository": {
     "type": "git",
     "url": "https://github.com/dmiller9911/jest-aphrodite-react"

--- a/src/__snapshots__/no-important.test.tsx.snap
+++ b/src/__snapshots__/no-important.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react-test-renderer 1`] = `
+.wrapper {
+  background: papayawhip;
+  padding: 4em;
+}
+
+.title {
+  color: palevioletred;
+  font-size: 1.5em;
+  text-align: center;
+}
+
+<section
+  className="wrapper"
+>
+  <h1
+    className="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;

--- a/src/no-important.test.tsx
+++ b/src/no-important.test.tsx
@@ -1,0 +1,46 @@
+import { css, StyleSheet } from 'aphrodite/no-important';
+import * as React from 'react';
+import * as reactTestRenderer from 'react-test-renderer';
+import { aphroditeSerializer } from './no-important';
+
+expect.addSnapshotSerializer(aphroditeSerializer);
+
+const Wrapper: React.SFC = props => {
+  const styles = StyleSheet.create({
+    wrapper: {
+      background: 'papayawhip',
+      padding: '4em',
+    },
+  });
+  return <section className={css(styles.wrapper)} {...props} />;
+};
+
+const Title: React.SFC = props => {
+  const styles = StyleSheet.create({
+    title: {
+      color: 'palevioletred',
+      fontSize: '1.5em',
+      textAlign: 'center',
+    },
+  });
+  return <h1 className={css(styles.title)} {...props} />;
+};
+
+test('react-test-renderer', () => {
+  const tree = reactTestRenderer
+    .create(
+      <Wrapper>
+        <Title>
+          Hello World, this is my first component styled with aphrodite!
+        </Title>
+      </Wrapper>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('no-important exports match default package exports', () => {
+  const defaultExports = require('.');
+  const noImportantExports = require('./no-important');
+  expect(Object.keys(defaultExports)).toEqual(Object.keys(noImportantExports));
+});

--- a/src/no-important.ts
+++ b/src/no-important.ts
@@ -1,7 +1,7 @@
 import { ClassNameReplacer, replaceClassNames } from './replaceClassNames';
 import { createSerializer, serializer, SerializerOptions } from './serializer';
 
-const aphroditeSerializer = serializer(true);
+const aphroditeSerializer = serializer(false);
 const { test, print } = aphroditeSerializer;
 
 export {

--- a/src/serializer.test.tsx
+++ b/src/serializer.test.tsx
@@ -3,7 +3,7 @@ import * as enzyme from 'enzyme';
 import toJson from 'enzyme-to-json';
 import * as React from 'react';
 import * as reactTestRenderer from 'react-test-renderer';
-import { aphroditeSerializer } from './serializer';
+import { aphroditeSerializer } from '.';
 
 expect.addSnapshotSerializer(aphroditeSerializer);
 

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -52,9 +52,11 @@ export function createSerializer(
 
 // doing this to make it easier for users to mock things
 // like switching between development mode and whatnot.
-const getAphroditeStyleSheetTestUtils = (): typeof StyleSheetTestUtils =>
-  require('aphrodite').StyleSheetTestUtils;
+const getAphroditeStyleSheetTestUtils = (
+  useImportant: boolean,
+) => (): typeof StyleSheetTestUtils =>
+  require(`aphrodite${useImportant ? '' : '/no-important'}`)
+    .StyleSheetTestUtils;
 
-export const aphroditeSerializer = createSerializer(
-  getAphroditeStyleSheetTestUtils,
-);
+export const serializer = (useImportant: boolean) =>
+  createSerializer(getAphroditeStyleSheetTestUtils(useImportant));

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,8 @@
     "variable-name": false,
     "object-literal-key-quotes": [true, "as-needed"],
     "object-literal-sort-keys": false,
-    "no-implicit-dependencies": false
+    "no-implicit-dependencies": false,
+    "no-submodule-imports": false
   },
   "linterOptions": {
     "exclude": ["lib/**"]


### PR DESCRIPTION
Currently the serializer doesn't work when using `aphrodite/no-important`, so here's my attempt to fix it.
It's possible to create a custom serializer with the `StyleSheetTestUtils` from the `no-important` import, but I prefer to use the `snapshotSerializers` option.