### PR TITLE
Adds support for multiple snapshots with react-testing-library

### DIFF
--- a/src/__snapshots__/serializer.test.tsx.snap
+++ b/src/__snapshots__/serializer.test.tsx.snap
@@ -415,3 +415,225 @@ exports[`when the root element does not have styles: react-testing-library 1`] =
   />
 </div>
 `;
+
+exports[`works on multiple snapshots: enzyme.mount 1`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<Wrapper>
+  <section
+    className="wrapper"
+  >
+    <Title>
+      <h1
+        className="title"
+      >
+        Hello World, this is my first component styled with aphrodite!
+      </h1>
+    </Title>
+  </section>
+</Wrapper>
+`;
+
+exports[`works on multiple snapshots: enzyme.mount 2`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<Wrapper>
+  <section
+    className="wrapper"
+  >
+    <Title>
+      <h1
+        className="title"
+      >
+        Hello World, this is my first component styled with aphrodite!
+      </h1>
+    </Title>
+  </section>
+</Wrapper>
+`;
+
+exports[`works on multiple snapshots: enzyme.render 1`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<section
+  class="wrapper"
+>
+  <h1
+    class="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;
+
+exports[`works on multiple snapshots: enzyme.render 2`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<section
+  class="wrapper"
+>
+  <h1
+    class="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;
+
+exports[`works on multiple snapshots: enzyme.shallow 1`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+<section
+  className="wrapper"
+>
+  <Title>
+    Hello World, this is my first component styled with aphrodite!
+  </Title>
+</section>
+`;
+
+exports[`works on multiple snapshots: enzyme.shallow 2`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+<section
+  className="wrapper"
+>
+  <Title>
+    Hello World, this is my first component styled with aphrodite!
+  </Title>
+</section>
+`;
+
+exports[`works on multiple snapshots: react-test-renderer 1`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<section
+  className="wrapper"
+>
+  <h1
+    className="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;
+
+exports[`works on multiple snapshots: react-test-renderer 2`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<section
+  className="wrapper"
+>
+  <h1
+    className="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;
+
+exports[`works on multiple snapshots: react-testing-library 1`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<section
+  class="wrapper"
+>
+  <h1
+    class="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;
+
+exports[`works on multiple snapshots: react-testing-library 2`] = `
+.wrapper {
+  background: papayawhip !important;
+  padding: 4em !important;
+}
+
+.title {
+  color: palevioletred !important;
+  font-size: 1.5em !important;
+  text-align: center !important;
+}
+
+<section
+  class="wrapper"
+>
+  <h1
+    class="title"
+  >
+    Hello World, this is my first component styled with aphrodite!
+  </h1>
+</section>
+`;

--- a/src/serializer.test.tsx
+++ b/src/serializer.test.tsx
@@ -85,3 +85,14 @@ test('supports pseudo selectors', () => {
   });
   checkSnapshotForEachMethod(<div className={css(styles.root)} />);
 });
+
+test('works on multiple snapshots', () => {
+  checkSnapshotForEachMethod(
+    <Wrapper>
+      <Title>
+        Hello World, this is my first component styled with aphrodite!
+      </Title>
+    </Wrapper>,
+    2
+  );
+});

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -13,6 +13,12 @@ interface TrackedHTMLElement extends HTMLElement {
   withStyles?: boolean;
 }
 
+interface TrackedReactTestRendererJSON extends ReactTestRendererJSON {
+  withStyles?: boolean;
+}
+
+type TrackedValue = TrackedHTMLElement | TrackedReactTestRendererJSON;
+
 export function createSerializer(
   getStyleSheetTestUtils: () => typeof StyleSheetTestUtils,
   { removeVendorPrefixes = false, classNameReplacer }: SerializerOptions = {},
@@ -26,9 +32,9 @@ export function createSerializer(
     );
   }
 
-  function print(val: ReactTestRendererJSON, printer: (val: any) => string) {
+  function print(val: TrackedValue, printer: (val: any) => string) {
     const nodes = getNodes(val);
-    nodes.forEach((node: any) => (node.withStyles = true));
+    nodes.forEach((node: TrackedValue) => (node.withStyles = true));
 
     const selectors = getSelectors(nodes);
     const styles = getStyles(
@@ -38,6 +44,8 @@ export function createSerializer(
     );
 
     const printedVal = printer(val);
+    delete val.withStyles;
+    nodes.forEach((node: TrackedValue) => delete node.withStyles);
 
     if (styles) {
       return replaceClassNames(

--- a/src/testUtil.ts
+++ b/src/testUtil.ts
@@ -3,17 +3,29 @@ import toJson from 'enzyme-to-json';
 import * as reactTestRenderer from 'react-test-renderer';
 import { render, cleanup } from 'react-testing-library';
 
-export function checkSnapshotForEachMethod(ui: JSX.Element) {
+export function checkSnapshotForEachMethod(ui: JSX.Element, times: number = 1) {
   const rtrResult = reactTestRenderer.create(ui).toJSON();
-  expect(rtrResult).toMatchSnapshot('react-test-renderer');
+  doTimes(times, () => {
+    expect(rtrResult).toMatchSnapshot('react-test-renderer');
+  });
 
   const enzymeMethods = ['shallow', 'mount', 'render'];
   enzymeMethods.forEach(method => {
     const tree = (enzyme as any)[method](ui);
-    expect(toJson(tree)).toMatchSnapshot(`enzyme.${method}`);
+    doTimes(times, () => {
+      expect(toJson(tree)).toMatchSnapshot(`enzyme.${method}`);
+    });
   });
 
   const { container } = render(ui);
-  expect(container.firstChild).toMatchSnapshot('react-testing-library');
+  doTimes(times, () => {
+    expect(container.firstChild).toMatchSnapshot('react-testing-library');
+  });
   cleanup();
+}
+
+function doTimes(times: number, fn: () => any) {
+  for (let i = 0; i < times; i += 1) {
+    fn();
+  }
 }


### PR DESCRIPTION
With react-testing-library, it's possible to do multiple snapshots on the same DOM. We were leaving the `withStyles` property set, which was causing all snapshots except the first to fail the `test` method. This cleans up the withStyles property after getting the style values to print for each node.